### PR TITLE
Update to latest Matter v1.4-branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,9 @@ jobs:
       matrix:
         arch:
           - name: x86-64
-            container: ghcr.io/project-chip/chip-build:81
             runner: ubuntu-22.04
             example-prefix: linux-x64-
           - name: aarch64
-            container: docker.io/agners/aarch64-chip-build:81
             runner: linux-arm64
             example-prefix: linux-arm64-
         include:
@@ -103,7 +101,7 @@ jobs:
         working-directory: ./connectedhomeip/
 
     container:
-      image: ${{ matrix.arch.container }}
+      image: ghcr.io/home-assistant-libs/chip-wheels/chip-wheels-builder:release
       volumes:
         - "/tmp/log_output:/tmp/test_logs"
       options: --sysctl "net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,7 +127,7 @@ jobs:
           ./scripts/examples/gn_build_example.sh \
               examples/ota-provider-app/linux/ \
               out/ \
-              chip_project_config_include_dirs=\[\"//../../../..\"\]
+              chip_project_config_include_dirs=\[\"//../../../..\"\] \
               chip_crypto=\"boringssl\" \
               chip_config_network_layer_ble=false \
               chip_enable_wifi=false \
@@ -135,7 +135,7 @@ jobs:
               chip_exchange_node_id_logging=true \
               chip_mdns=\"minimal\" \
               chip_minmdns_default_policy=\"libnl\" \
-              chip_use_data_model_interface=\"enabled\" \
+              chip_use_data_model_interface=\"enabled\"
           cp out/chip-ota-provider-app bin/
       - name: Rename and strip symbols
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,11 @@ jobs:
       matrix:
         arch:
           - name: x86-64
-            container: ghcr.io/project-chip/chip-build:42
+            container: ghcr.io/project-chip/chip-build:81
             runner: ubuntu-22.04
             example-prefix: linux-x64-
           - name: aarch64
-            container: docker.io/agners/aarch64-chip-build:42
+            container: docker.io/agners/aarch64-chip-build:81
             runner: linux-arm64
             example-prefix: linux-arm64-
         include:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
           done
       - name: Bootstrap
         working-directory: ./connectedhomeip/
-        run: bash scripts/bootstrap.sh -p all,linux
+        run: bash scripts/bootstrap.sh -p build,linux
       - name: ZAP Code pre-generation
         working-directory: ./connectedhomeip/
         run: scripts/run_in_build_env.sh "scripts/codepregen.py ./zzz_pregenerated/"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,12 +129,15 @@ jobs:
           ./scripts/examples/gn_build_example.sh \
               examples/ota-provider-app/linux/ \
               out/ \
+              chip_project_config_include_dirs=\[\"//../../../..\"\]
+              chip_crypto=\"boringssl\" \
               chip_config_network_layer_ble=false \
               chip_enable_wifi=false \
               chip_enable_openthread=false \
+              chip_exchange_node_id_logging=true \
+              chip_mdns=\"minimal\" \
               chip_minmdns_default_policy=\"libnl\" \
-              chip_crypto=\"boringssl\" \
-              chip_project_config_include_dirs=\[\"//../../../..\"\]
+              chip_use_data_model_interface=\"enabled\" \
           cp out/chip-ota-provider-app bin/
       - name: Rename and strip symbols
         run: |

--- a/CHIPProjectAppConfig.h
+++ b/CHIPProjectAppConfig.h
@@ -77,16 +77,15 @@
 //
 #define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS 150
 
-// Safe to enable this flag since standalone is associated with host and not a device.
-#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 0
 
 // Allows app options (ports) to be configured on launch of app
 // from examples/ota-provider-app/linux/include/CHIPProjectAppConfig.h
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1
 
 #define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "1"
-#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "2024.7.0"
-#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION 1
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "2025.5.0"
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION 2
 #define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_NAME "Nabu Casa"
 #define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME "OTA Provider"
 

--- a/CHIPProjectAppConfig.h
+++ b/CHIPProjectAppConfig.h
@@ -62,6 +62,9 @@
 
 #define CHIP_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL 1
 
+// Increase maximum retransmit from 4 to 8 to handle unreliable devices
+#define CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS 8
+
 #ifndef CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT
 #define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT 4
 #endif


### PR DESCRIPTION
Update the OTA Provider to latest v1.4-branch. Compared to the previous v1.3 based OTA Provider this includes some fixes around retry timings (like https://github.com/project-chip/connectedhomeip/pull/37696) which may help communication with Thread devices.